### PR TITLE
Resolved non varname bento warnings

### DIFF
--- a/measure
+++ b/measure
@@ -59,7 +59,8 @@ class AB(Measure):
         self.print_measure_error(err, ST_FAILED)
         try:
             self.proc.terminate()
-        except:
+        # No sec below as process should be terminated by sys.exit if the above fails
+        except: # nosec
             pass
         sys.exit(3)
 


### PR DESCRIPTION
Bento Output:

```
bandit try-except-pass https://bandit.readthedocs.io/en/latest/plugins/b110_try_except_pass.html
     > measure_driver.py:62                                                           
     ╷                                                                                
   62│   except:                                                                      
     ╵
     = Try, Except, Pass detected.

flake8 ambiguous-variable-name https://lintlyci.github.io/Flake8Rules/rules/E741.html
     > measure_driver.py:235
     ╷
  235│   l = line.decode().strip()
     ╵
     = ambiguous variable name 'l'
```