### PR TITLE
Added AB_N and AB_T envars for n_threads, n_requests, t_limit, t_warmup

### DIFF
--- a/README.md
+++ b/README.md
@@ -9,8 +9,13 @@ Optune servo driver for Apache Benchmark
 ```
 ["Host: hostname.local", "X-AUTH-TOKEN: aTokenForAuthentication"]
 ```
+* `AB_N_THREADS` - Number of multiple requests to perform at a time.
+* `AB_N_REQUESTS` - Number of requests to perform for the benchmarking session.
+* `AB_T_LIMIT` - Maximum number of seconds to spend for benchmarking.
+* `AB_T_WARMUP` - Number of seconds to wait after start to perform measurement.
 
-Note: Control parameters take precedence over environment variables.
+Note: Control parameters can also be defined in code.  There are defaults for
+AB_N and AB_T parameters if not specified as environment variables.
 
 ## Supported control parameters:
 

--- a/measure
+++ b/measure
@@ -12,7 +12,7 @@ import json
 from threading import Timer
 
 DESC="Apache Benchmark measure driver for Opsani Optune"
-VERSION="1.0.0"
+VERSION="1.0.1"
 HAS_CANCEL=True
 PROGRESS_INTERVAL=30
 
@@ -79,6 +79,15 @@ class AB(Measure):
         load_cfg.update(load) # will override test_url and headers if provided in load
         if not load_cfg['test_url']:
             raise Exception('Load configuration is missing a test_url')
+
+        if os.environ.get('AB_N_THREADS'):
+            load_cfg['n_threads'] = os.environ.get('AB_N_THREADS')
+        if os.environ.get('AB_N_REQUESTS'):
+            load_cfg['n_requests'] = os.environ.get('AB_N_REQUESTS')
+        if os.environ.get('AB_T_LIMIT'):
+            load_cfg['t_limit'] = os.environ.get('AB_T_LIMIT')
+        if os.environ.get('AB_T_WARMUP'):
+            load_cfg['t_warmup'] = os.environ.get('AB_T_WARMUP')
 
         result, command = self._run_ab(
             test_url      = load_cfg['test_url'],


### PR DESCRIPTION
Iteratively better than before but not control through config-state.yaml.  These important params were hardcoded and this change proposes to expose them as envars.